### PR TITLE
Add root to xpo-edit.owl

### DIFF
--- a/src/ontology/xpo-edit.owl
+++ b/src/ontology/xpo-edit.owl
@@ -23,6 +23,7 @@ Annotation(<http://purl.org/dc/elements/1.1/description> "XPO represents anatomi
 Annotation(<http://purl.org/dc/elements/1.1/title> "Xenopus Phenotype Ontology"^^xsd:string)
 Annotation(<http://purl.org/dc/terms/license> <https://creativecommons.org/licenses/by/3.0/>)
 Annotation(rdfs:comment "Citation: Fisher ME, Segerdell E, Matentzoglu N, Nenni MJ, Fortriede JD, Chu S, Pells TJ, Osumi-Sutherland D, Chaturvedi P, James-Zorn C, Sundararaj N, Lotay VS, Ponferrada V, Wang DZ, Kim E, Agalakov S, Arshinoff BI, Karimi K, Vize PD, Zorn AM. The Xenopus phenotype ontology: bridging model organism phenotype data to human health and development. BMC Bioinformatics. 2022 Mar 22;23(1):99. doi: 10.1186/s12859-022-04636-8."^^xsd:string)
+Annotation(<http://purl.obolibrary.org/obo/IAO_0000700> <http://purl.obolibrary.org/obo/XAO_0000000>)
 
 Declaration(Class(<http://purl.obolibrary.org/obo/XPO_00000000>))
 Declaration(AnnotationProperty(<http://purl.org/dc/elements/1.1/description>))


### PR DESCRIPTION
Related to https://github.com/OBOFoundry/OBOFoundry.github.io/issues/2149

# What this Does
Applies the annotation property [has ontology root term (IAO:0000700)](http://purl.obolibrary.org/obo/IAO_0000700) to XAO:0000000

# Why this is helpful
the Ontology Lookup Service uses this to help better display ontologies
if the term mentioned above is ever aligned with an upper ontology like BFO, it still will be the thing shown on OLS as the "root"
this will be generally useful for things like alignment with COB since it makes it easier to figure out where the work will be

cc @matentzn and @cthoyt