### PR TITLE
Change the main "phenotype" class to 7 digits

### DIFF
--- a/src/ontology/xpo-edit.owl
+++ b/src/ontology/xpo-edit.owl
@@ -19,12 +19,13 @@ Import(<http://purl.obolibrary.org/obo/xpo/patterns/definitions.owl>)
 Import(<http://purl.obolibrary.org/obo/xpo/patterns/templates/xpo-obsolete.owl>)
 Import(<http://purl.obolibrary.org/obo/xpo/patterns/templates/xpo-replaced.owl>)
 Import(<http://purl.obolibrary.org/obo/xpo/patterns/templates/xpo-xrefs.owl>)
-Annotation(<http://purl.org/dc/elements/1.1/description> "XPO represents anatomical, cellular, and gene function phenotypes occurring throughout the development of the African frogs Xenopus laevis and tropicalis."^^xsd:string)
-Annotation(<http://purl.org/dc/elements/1.1/title> "Xenopus Phenotype Ontology"^^xsd:string)
+Annotation(<http://purl.obolibrary.org/obo/IAO_0000700> <http://purl.obolibrary.org/obo/XPO_0000000>)
+Annotation(<http://purl.org/dc/elements/1.1/description> "XPO represents anatomical, cellular, and gene function phenotypes occurring throughout the development of the African frogs Xenopus laevis and tropicalis.")
+Annotation(<http://purl.org/dc/elements/1.1/title> "Xenopus Phenotype Ontology")
 Annotation(<http://purl.org/dc/terms/license> <https://creativecommons.org/licenses/by/3.0/>)
-Annotation(rdfs:comment "Citation: Fisher ME, Segerdell E, Matentzoglu N, Nenni MJ, Fortriede JD, Chu S, Pells TJ, Osumi-Sutherland D, Chaturvedi P, James-Zorn C, Sundararaj N, Lotay VS, Ponferrada V, Wang DZ, Kim E, Agalakov S, Arshinoff BI, Karimi K, Vize PD, Zorn AM. The Xenopus phenotype ontology: bridging model organism phenotype data to human health and development. BMC Bioinformatics. 2022 Mar 22;23(1):99. doi: 10.1186/s12859-022-04636-8."^^xsd:string)
-Annotation(<http://purl.obolibrary.org/obo/IAO_0000700> <http://purl.obolibrary.org/obo/XPO_00000000>)
+Annotation(rdfs:comment "Citation: Fisher ME, Segerdell E, Matentzoglu N, Nenni MJ, Fortriede JD, Chu S, Pells TJ, Osumi-Sutherland D, Chaturvedi P, James-Zorn C, Sundararaj N, Lotay VS, Ponferrada V, Wang DZ, Kim E, Agalakov S, Arshinoff BI, Karimi K, Vize PD, Zorn AM. The Xenopus phenotype ontology: bridging model organism phenotype data to human health and development. BMC Bioinformatics. 2022 Mar 22;23(1):99. doi: 10.1186/s12859-022-04636-8.")
 
+Declaration(Class(<http://purl.obolibrary.org/obo/XPO_0000000>))
 Declaration(Class(<http://purl.obolibrary.org/obo/XPO_00000000>))
 Declaration(AnnotationProperty(<http://purl.org/dc/elements/1.1/description>))
 Declaration(AnnotationProperty(<http://purl.org/dc/elements/1.1/title>))
@@ -36,11 +37,18 @@ Declaration(AnnotationProperty(<http://purl.org/dc/terms/license>))
 #   Classes
 ############################
 
-# Class: <http://purl.obolibrary.org/obo/XPO_00000000> (Xenopus phenotype)
+# Class: <http://purl.obolibrary.org/obo/XPO_0000000> (Xenopus phenotype)
 
-AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/XPO_00000000> "A phenotype observed in Xenopus."^^xsd:string)
-AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/XPO_00000000> "Xenopus phenotype"@en)
-EquivalentClasses(<http://purl.obolibrary.org/obo/XPO_00000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> owl:Thing))))
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0000115> <http://purl.obolibrary.org/obo/XPO_0000000> "A phenotype observed in Xenopus.")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/XPO_0000000> "Xenopus phenotype"@en)
+EquivalentClasses(<http://purl.obolibrary.org/obo/XPO_0000000> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/BFO_0000051> ObjectIntersectionOf(<http://purl.obolibrary.org/obo/PATO_0000001> ObjectSomeValuesFrom(<http://purl.obolibrary.org/obo/RO_0002314> owl:Thing))))
+
+# Class: <http://purl.obolibrary.org/obo/XPO_00000000> (obsolete Xenopus phenotype)
+
+AnnotationAssertion(<http://purl.obolibrary.org/obo/IAO_0100001> <http://purl.obolibrary.org/obo/XPO_00000000> "XPO:0000000")
+AnnotationAssertion(rdfs:comment <http://purl.obolibrary.org/obo/XPO_00000000> "This class was obsoleted because it had too many digits (8 instead of 7).")
+AnnotationAssertion(rdfs:label <http://purl.obolibrary.org/obo/XPO_00000000> "obsolete Xenopus phenotype")
+AnnotationAssertion(owl:deprecated <http://purl.obolibrary.org/obo/XPO_00000000> "true"^^xsd:boolean)
 
 
 )


### PR DESCRIPTION
All XPO Ids have 7 digits. Due to an ommission in the beginning of the XPO development process, the root class has 8 digits. To harmonise this, I would like to suggest to change the number of digits..

@seger I know these are scary changes, but I wanted to see if you would consider it. Some of our tooling relies on the assumption that the ID has exactly 7 digits. 